### PR TITLE
FIX Downsampling Bugs

### DIFF
--- a/murenn/dtcwt/nn.py
+++ b/murenn/dtcwt/nn.py
@@ -178,7 +178,6 @@ class Downsampling(torch.nn.Module):
             J=1,
             level1="near_sym_b",
             skip_hps=True,
-            padding_mode="zeros",
         )
 
 

--- a/murenn/dtcwt/nn.py
+++ b/murenn/dtcwt/nn.py
@@ -75,7 +75,7 @@ class MuReNNDirect(torch.nn.Module):
             Wx_j_r = self.conv1d[j](bps[j].real)
             Wx_j_i = self.conv1d[j](bps[j].imag)
             UWx_j = ModulusStable.apply(Wx_j_r, Wx_j_i)
-            UWx_j = self.down[j](UWx_j)
+            UWx_j = self.down[j](UWx_j) * math.sqrt(2) ** j
             B, _, N = UWx_j.shape
             UWx_j = UWx_j.view(B, self.in_channels, self.Q[j], N)
             UWx.append(UWx_j)

--- a/murenn/dtcwt/nn.py
+++ b/murenn/dtcwt/nn.py
@@ -10,8 +10,7 @@ class MuReNNDirect(torch.nn.Module):
     Args:
         J (int): Number of levels (octaves) in the DTCWT decomposition.
         Q (int or list): Number of Conv1D filters per octave.
-        T (int): Conv1D Kernel size multiplier. The Conv1d kernel size at scale j is equal to
-          T * Q[j] where Q[j] is the number of filters.
+        T (int): Conv1D Kernel size.
         J_phi (int): Number of levels of downsampling. Stride is 2**J_phi. Default is J.
         in_channels (int): Number of channels in the input signal.
         padding_mode (str): One of 'symmetric' (default), 'zeros', 'replicate',
@@ -30,7 +29,7 @@ class MuReNNDirect(torch.nn.Module):
             J_phi = J
         if J_phi < J:
             raise ValueError("J_phi must be greater or equal to J")
-        self.T = [T*self.Q[j] for j in range(J)]
+        self.T = [T for j in range(J)]
         self.in_channels = in_channels
         self.padding_mode = padding_mode
         down = []

--- a/murenn/dtcwt/nn.py
+++ b/murenn/dtcwt/nn.py
@@ -10,7 +10,7 @@ class MuReNNDirect(torch.nn.Module):
     Args:
         J (int): Number of levels (octaves) in the DTCWT decomposition.
         Q (int or list): Number of Conv1D filters per octave.
-        T (int): Conv1D Kernel size.
+        T (int): The Conv1d kernel size.
         J_phi (int): Number of levels of downsampling. Stride is 2**J_phi. Default is J.
         in_channels (int): Number of channels in the input signal.
         padding_mode (str): One of 'symmetric' (default), 'zeros', 'replicate',
@@ -29,7 +29,7 @@ class MuReNNDirect(torch.nn.Module):
             J_phi = J
         if J_phi < J:
             raise ValueError("J_phi must be greater or equal to J")
-        self.T = [T for j in range(J)]
+        self.T = T
         self.in_channels = in_channels
         self.padding_mode = padding_mode
         down = []
@@ -37,14 +37,13 @@ class MuReNNDirect(torch.nn.Module):
         self.dtcwt = murenn.DTCWT(
             J=J,
             padding_mode=padding_mode,
-            alternate_gh=False,
         )
 
         for j in range(J):
             conv1d_j = torch.nn.Conv1d(
                 in_channels=in_channels,
                 out_channels=self.Q[j]*in_channels,
-                kernel_size=self.T[j],
+                kernel_size=self.T,
                 bias=False,
                 groups=in_channels,
                 padding="same",
@@ -52,7 +51,7 @@ class MuReNNDirect(torch.nn.Module):
             torch.nn.init.normal_(conv1d_j.weight)
             conv1d.append(conv1d_j)
     
-            down_j = Downsampling(J_phi - j)
+            down_j = Downsampling(J_phi - j -1)
             down.append(down_j)
 
         self.down = torch.nn.ModuleList(down)
@@ -95,44 +94,58 @@ class MuReNNDirect(torch.nn.Module):
         """
 
         device = self.conv1d[0].weight.data.device
-        # T the filter length
-        T = max(self.T)
-        # J the number of levels of decompostion
-        J = self.dtcwt.J
+        T = self.T  # Filter length
+        J = self.dtcwt.J  # Number of levels of decomposition
+        N = 2 ** J * T  # Length of the impulse signal
+
         # Generate the impulse signal
-        N = 2 ** J * T
         x = torch.zeros(1, self.in_channels, N).to(device)
         x[:, :, N//2] = 1
-        inv = murenn.IDTCWT(
-            J = J,
-            alternate_gh=False         
-        ).to(device)
+
+        # Initialize the inverse DTCWT
+        inv = murenn.IDTCWT(J=J, alternate_gh=False).to(device)
+
         # Get DTCWT impulse reponses
         phi, psis = self.dtcwt(x)
-        # Set phi to a zero valued tensor
         zeros_phi = phi.new_zeros(1, 1, phi.shape[-1])
-        ws = []
+
+        ws_r, ws_i, ws = [], [], []
         for j in range(J):
             Wpsi_jr = self.conv1d[j](psis[j].real).reshape(self.in_channels, self.Q[j], -1)
             Wpsi_ji = self.conv1d[j](psis[j].imag).reshape(self.in_channels, self.Q[j], -1)
             for q in range(self.Q[j]):
                 Wpsi_jqr = Wpsi_jr[0, q, :].reshape(1,1,-1)
                 Wpsi_jqi = Wpsi_ji[0, q, :].reshape(1,1,-1)
+                Wpsi_jq = torch.complex(Wpsi_jqr, Wpsi_jqi)
+
                 Wpsis_r = [Wpsi_jqr * (1+0j) if k == j else psis[k].new_zeros(1,1,psis[k].shape[-1]) for k in range(J)]
                 Wpsis_i = [Wpsi_jqi * (0+1j) if k == j else psis[k].new_zeros(1,1,psis[k].shape[-1]) for k in range(J)]
-                w_r = inv(zeros_phi, Wpsis_r)
-                w_i = inv(zeros_phi, Wpsis_i)
-                ws.append(torch.complex(w_r, w_i))
+                Wpsis = [Wpsi_jq if k == j else psis[k].new_zeros(1,1,psis[k].shape[-1]) for k in range(J)]
+
+                ws_r.append(inv(zeros_phi, Wpsis_r))
+                ws_i.append(inv(zeros_phi, Wpsis_i))
+                ws.append(inv(zeros_phi, Wpsis))
+        
         ws = torch.cat(ws, dim=0)
-        conv1d = torch.nn.Conv1d(
-            in_channels=1,
-            out_channels=ws.shape[0],
-            kernel_size=N,
-            bias=False,
-            padding="same",
-        )
-        conv1d.weight.data = torch.nn.parameter.Parameter(ws)
-        return conv1d
+        ws_r = torch.cat(ws_r, dim=0)
+        ws_i = torch.cat(ws_i, dim=0)
+
+        def create_conv1d(weight):
+            conv1d = torch.nn.Conv1d(
+                in_channels=1,
+                out_channels=weight.shape[0],
+                kernel_size=N,
+                bias=False,
+                padding="same",
+            )
+            conv1d.weight.data = torch.nn.parameter.Parameter(weight)
+            return conv1d
+
+        return {
+            "complex": create_conv1d(ws),
+            "real": create_conv1d(ws_r),
+            "imag": create_conv1d(ws_i),
+        }
 
 
 class ModulusStable(torch.autograd.Function):
@@ -179,10 +192,12 @@ class Downsampling(torch.nn.Module):
             level1="near_sym_b",
             skip_hps=True,
         )
+        self.relu = torch.nn.ReLU()
 
 
     def forward(self, x):
         for j in range(self.J_phi):
             x, _ = self.phi(x)
+            # Normalize the coefficients
             x = x[:,:,::2]
-        return x
+        return self.relu(x)

--- a/murenn/dtcwt/nn.py
+++ b/murenn/dtcwt/nn.py
@@ -185,6 +185,5 @@ class Downsampling(torch.nn.Module):
     def forward(self, x):
         for j in range(self.J_phi):
             x, _ = self.phi(x)
-            # Normalize the coefficients
-            x = x[:,:,::2] / math.sqrt(2)
+            x = x[:,:,::2]
         return x

--- a/murenn/dtcwt/transform1d.py
+++ b/murenn/dtcwt/transform1d.py
@@ -16,7 +16,7 @@ class DTCWT(torch.nn.Module):
         J=8,
         skip_hps=False,
         include_scale=False,
-        alternate_gh=True,
+        alternate_gh=False,
         padding_mode="symmetric",
         normalize=True,
     ):

--- a/murenn/dtcwt/transform1d.py
+++ b/murenn/dtcwt/transform1d.py
@@ -136,14 +136,9 @@ class DTCWTDirect(DTCWT):
             x = torch.cat((x, x[:,:,-1:]), dim=-1)
 
         ## LEVEL 1 ##
-        # if self.normalize:
-        #     x = 1/np.sqrt(2) * x
         x_phi, x_psi_r, x_psi_i = FWD_J1.apply(
             x, self.h0o, self.h1o, self.skip_hps[0], self.padding_mode
         )
-        if self.normalize:
-            x_psi_r = 1/np.sqrt(2) * x_psi_r
-            x_psi_i = 1/np.sqrt(2) * x_psi_i
         x_psis.append(x_psi_r + 1j * x_psi_i)
         if self.include_scale[0]:
             x_phis.append(x_phi)
@@ -162,8 +157,8 @@ class DTCWTDirect(DTCWT):
             # Ensure the lowpass is divisible by 4
             if x_phi.shape[-1] % 4 != 0:
                 x_phi = torch.cat((x_phi[:,:,0:1], x_phi, x_phi[:,:,-1:]), dim=-1)
-            # if self.normalize:
-            #     x_phi = 1/np.sqrt(2) * x_phi
+            if self.normalize:
+                x_phi = 1/np.sqrt(2) * x_phi
             x_phi, x_psi_r, x_psi_i = FWD_J2PLUS.apply(
                 x_phi,
                 h0a,
@@ -173,12 +168,6 @@ class DTCWTDirect(DTCWT):
                 self.skip_hps[j],
                 self.padding_mode,
             )
-            if self.normalize:
-                # x_psi_r = 1/np.sqrt(2) * x_psi_r
-                # x_psi_i = 1/np.sqrt(2) * x_psi_i
-                x_phi = 1/np.sqrt(2) * x_phi
-                x_psi_r = 1/2 * x_psi_r
-                x_psi_i = 1/2 * x_psi_i
             if (j % 2 == 1) and self.alternate_gh:
                 # The result is anti-analytic in the Hilbert sense.
                 # We conjugate the result to bring the spectrum back to (0, pi).
@@ -361,12 +350,6 @@ class DTCWTInverse(DTCWT):
             else:
                 g0a, g1a, g0b, g1b = self.g0a, self.g1a, self.g0b, self.g1b
 
-            if self.normalize:
-                # x_psi = np.sqrt(2) * x_psi
-                # x_phi = np.sqrt(2) * x_phi
-                x_psi = 2 * x_psi
-                x_phi = np.sqrt(2) * x_phi
-
             x_psi_r, x_psi_i = x_psi.real, x_psi.imag
             x_phi = INV_J2PLUS.apply(
                 x_phi,
@@ -378,21 +361,18 @@ class DTCWTInverse(DTCWT):
                 g1b,
                 self.padding_mode,
             )
-            # if self.normalize:
-            #     x_phi = np.sqrt(2) * x_phi
+            if self.normalize:
+                x_phi = np.sqrt(2) * x_phi
 
         # LEVEL 1 ##
         if x_phi.shape[-1] != x_psis[0].shape[-1] * 2:
             x_phi = x_phi[:,:,1:-1]
 
-        if self.normalize:
-            x_psis[0] = np.sqrt(2) * x_psis[0]
         x_psi_r, x_psi_i = x_psis[0].real, x_psis[0].imag
+
         x_phi = INV_J1.apply(
             x_phi, x_psi_r, x_psi_i, self.g0o, self.g1o, self.padding_mode
         )
-        # if self.normalize:
-        #     x_phi = np.sqrt(2) * x_phi
         if self.length:
             x_phi = fix_length(x_phi, size=self.length)
         return x_phi

--- a/tests/test_dtcwt.py
+++ b/tests/test_dtcwt.py
@@ -81,13 +81,13 @@ def test_skip_hps(skip_hps, normalize):
     assert torch.allclose(lp, lp_ap)
 
 
-@pytest.mark.parametrize("J", range(3))
+@pytest.mark.parametrize("J", range(1,4))
 @pytest.mark.parametrize("alternate_gh", [True, False])
 def test_phi(J, alternate_gh):
     '''
     Test the low-pass output phi doesn't diverge.
     '''
-    tfm = murenn.DTCWT(J=J+1, alternate_gh=alternate_gh, include_scale=True, skip_hps=True)
+    tfm = murenn.DTCWT(J=J, alternate_gh=alternate_gh, include_scale=True, skip_hps=True)
     N = 2**15
     x = torch.ones(1, 1, N)
     phis, _ = tfm(x)
@@ -116,13 +116,13 @@ def test_energy_preservation(alternate_gh):
     assert torch.abs(ratio - 1) <= 0.01
 
 
-@pytest.mark.parametrize("J", range(3))
+@pytest.mark.parametrize("J", range(1, 4))
 @pytest.mark.parametrize("alternate_gh", [True, False])
 def test_avrg_energy(J, alternate_gh):
     '''
     Test the power of the signals for normalization case.
     '''
-    tfm = murenn.DTCWT(J=J+1, alternate_gh=alternate_gh, normalize=True)
+    tfm = murenn.DTCWT(J=J, alternate_gh=alternate_gh, normalize=True)
     N = 2**15
     x = torch.randn(1 ,1, N)
     P_x = torch.linalg.norm(x) ** 2 / x.shape[-1]

--- a/tests/test_dtcwt.py
+++ b/tests/test_dtcwt.py
@@ -131,6 +131,7 @@ def test_avrg_energy(J, alternate_gh):
     P_phi = torch.linalg.norm(phi) ** 2 / phi.shape[-1]
     P_Ux = P_Ux + P_phi
     for psi in psis:
+        psi = psi / math.sqrt(2)
         Ppsi_j = torch.linalg.norm(torch.abs(psi)) ** 2 / psi.shape[-1]
         P_Ux = P_Ux + Ppsi_j
     ratio = P_Ux / P_x

--- a/tests/test_dtcwt.py
+++ b/tests/test_dtcwt.py
@@ -81,12 +81,13 @@ def test_skip_hps(skip_hps, normalize):
     assert torch.allclose(lp, lp_ap)
 
 
+@pytest.mark.parametrize("J", range(3))
 @pytest.mark.parametrize("alternate_gh", [True, False])
-def test_phi(alternate_gh):
+def test_phi(J, alternate_gh):
     '''
     Test the low-pass output phi doesn't diverge.
     '''
-    tfm = murenn.DTCWT(alternate_gh=alternate_gh, include_scale=True, skip_hps=True)
+    tfm = murenn.DTCWT(J=J+1, alternate_gh=alternate_gh, include_scale=True, skip_hps=True)
     N = 2**15
     x = torch.ones(1, 1, N)
     phis, _ = tfm(x)
@@ -115,12 +116,13 @@ def test_energy_preservation(alternate_gh):
     assert torch.abs(ratio - 1) <= 0.01
 
 
+@pytest.mark.parametrize("J", range(3))
 @pytest.mark.parametrize("alternate_gh", [True, False])
-def test_avrg_energy(alternate_gh):
+def test_avrg_energy(J, alternate_gh):
     '''
     Test the power of the signals for normalization case.
     '''
-    tfm = murenn.DTCWT(alternate_gh=alternate_gh, normalize=True)
+    tfm = murenn.DTCWT(J=J+1, alternate_gh=alternate_gh, normalize=True)
     N = 2**15
     x = torch.randn(1 ,1, N)
     P_x = torch.linalg.norm(x) ** 2 / x.shape[-1]
@@ -129,7 +131,6 @@ def test_avrg_energy(alternate_gh):
     P_phi = torch.linalg.norm(phi) ** 2 / phi.shape[-1]
     P_Ux = P_Ux + P_phi
     for psi in psis:
-        psi = psi / math.sqrt(2) #?
         Ppsi_j = torch.linalg.norm(torch.abs(psi)) ** 2 / psi.shape[-1]
         P_Ux = P_Ux + Ppsi_j
     ratio = P_Ux / P_x

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -91,7 +91,7 @@ def test_modulus():
 
 @pytest.mark.parametrize("Q", [1, 2])
 @pytest.mark.parametrize("T", [1, 2])
-def test_toconv1d_shape(Q, T):
+def test_toconv1d(Q, T):
     J = 4
     tfm = murenn.MuReNNDirect(
         J=J,
@@ -99,34 +99,8 @@ def test_toconv1d_shape(Q, T):
         T=T,
         in_channels=2,
     )
-    conv1d = tfm.to_conv1d()
-    assert isinstance(conv1d, torch.nn.Conv1d)
-
-@pytest.mark.parametrize("J", range(3))
-@pytest.mark.parametrize("alternate_gh", [True, False])
-def test_avrg_energy(J, alternate_gh):
-    '''
-    Test the power of the signals for normalization case.
-    '''
-    tfm = murenn.DTCWT(J=J+1, alternate_gh=alternate_gh, normalize=True)
-    N = 2**15
-    x = torch.randn(1 ,1, N)
-    P_x = torch.linalg.norm(x) ** 2 / x.shape[-1]
-    P_Ux = 0
-    phi, psis = tfm(x)
-    P_phi = torch.linalg.norm(phi) ** 2 / phi.shape[-1]
-    P_Ux = P_Ux + P_phi
-    for psi in psis:
-        Ppsi_j = torch.linalg.norm(torch.abs(psi)) ** 2 / psi.shape[-1]
-        P_Ux = P_Ux + Ppsi_j
-    ratio = P_Ux / P_x
-    assert torch.abs(ratio - 1) <= 0.01
-
-
-@pytest.mark.parametrize("J_phi", range(3))
-def test_down(J_phi):
-    N = 2**15
-    x = torch.ones(1, 1, N)
-    down = murenn.dtcwt.nn.Downsampling(J_phi)
-    x_down = down(x)
-    assert torch.allclose(x_down, torch.ones(1, 1, N // 2**J_phi))
+    x = torch.zeros(1, 1, 2**J)
+    conv1ds = tfm.to_conv1d()
+    for k, v in conv1ds.items():
+        assert isinstance(v, torch.nn.Conv1d)
+        y = v(x)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1,3 +1,4 @@
+import murenn.dtcwt
 import pytest
 import torch
 import murenn
@@ -100,3 +101,32 @@ def test_toconv1d_shape(Q, T):
     )
     conv1d = tfm.to_conv1d()
     assert isinstance(conv1d, torch.nn.Conv1d)
+
+@pytest.mark.parametrize("J", range(3))
+@pytest.mark.parametrize("alternate_gh", [True, False])
+def test_avrg_energy(J, alternate_gh):
+    '''
+    Test the power of the signals for normalization case.
+    '''
+    tfm = murenn.DTCWT(J=J+1, alternate_gh=alternate_gh, normalize=True)
+    N = 2**15
+    x = torch.randn(1 ,1, N)
+    P_x = torch.linalg.norm(x) ** 2 / x.shape[-1]
+    P_Ux = 0
+    phi, psis = tfm(x)
+    P_phi = torch.linalg.norm(phi) ** 2 / phi.shape[-1]
+    P_Ux = P_Ux + P_phi
+    for psi in psis:
+        Ppsi_j = torch.linalg.norm(torch.abs(psi)) ** 2 / psi.shape[-1]
+        P_Ux = P_Ux + Ppsi_j
+    ratio = P_Ux / P_x
+    assert torch.abs(ratio - 1) <= 0.01
+
+
+@pytest.mark.parametrize("J_phi", range(3))
+def test_down(J_phi):
+    N = 2**15
+    x = torch.ones(1, 1, N)
+    down = murenn.dtcwt.nn.Downsampling(J_phi)
+    x_down = down(x)
+    assert torch.allclose(x_down, torch.ones(1, 1, N // 2**J_phi))

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 import murenn
 
-from murenn.dtcwt.nn import ModulusStable
+from murenn.dtcwt.nn import ModulusStable, Downsampling
 
 
 if torch.cuda.is_available():
@@ -99,8 +99,12 @@ def test_toconv1d(Q, T):
         T=T,
         in_channels=2,
     )
-    x = torch.zeros(1, 1, 2**J)
+    N = 2**J*16
+    x = torch.randn(1, 1, N)
     conv1ds = tfm.to_conv1d()
-    for k, v in conv1ds.items():
-        assert isinstance(v, torch.nn.Conv1d)
-        y = v(x)
+    for conv1d in conv1ds.values():
+        assert isinstance(conv1d, torch.nn.Conv1d)
+        y = conv1d(x)
+        assert isinstance(y, torch.Tensor)
+        assert y.dtype == x.dtype
+        assert y.shape == (1, J*Q, N)


### PR DESCRIPTION
Changed default arguments in DTCWT:
1. Set `alternate_gh=False` as the default value for `dtcwt`
2.  Resolved an issue where the normalization during downsampling was incorrect.
4. Enhanced to_conv1d method
5. Adjusted the downsampling level to optimize performance and accuracy.